### PR TITLE
Clarifying Field Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ spec:
       statusConditionHooks:
       - matchers:
         - resources: 
+          # Note that "name" refers to the resource's identifier within the
+          # Composition and not the object's metadata.name. 
+          # Related documentation:
+          # https://docs.crossplane.io/latest/guides/function-patch-and-transform/#resource-templates
           - name: "cloudsql-instance"
           conditions:
           - type: Synced


### PR DESCRIPTION
### Description of your changes

Adds documentation to clarify the usage of the `matchers[*].reosurces[*].name` field.

Fixes #34 


I have:
- [x] Read and followed Crossplane's contribution process.
- [ ] ~Added or updated unit tests for my change.~
