### PR TITLE
Extra resources names now include the into field.

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,10 +237,15 @@ You can match resources that are included by the [extra-resources
 function](https://github.com/crossplane-contrib/function-extra-resources). To do
 this you will need to set `includeExtraResources` to true and then match the
 desired extra resources. Extra resources follow the pattern
-`extra-resource.<group>.<kind>.<namespace>.name` (e.g.,
-`extra-resource.apps.Deployment.default.nginx`). Note that cluster-scoped
-resources will have an empty namespace segment (e.g.,
-`extra-resource.rbac.authorization.k8s.io.ClusterRole..admin`).
+`extra-resource.<into>.<group>.<kind>.<namespace>.<name>` (e.g.,
+`extra-resource.Deployment.apps.Deployment.default.nginx`).
+
+Notes:
+
+- Cluster-scoped resources will have an empty namespace segment (e.g.,
+`extra-resource.ClusterRole.rbac.authorization.k8s.io.ClusterRole..admin`).
+- `into` refers to the extra-resource function's Input field at
+`<Input>.spec.extraResources[*].into`.
 
 ```yaml
 apiVersion: function-status-transformer.fn.crossplane.io/v1beta1
@@ -249,7 +254,7 @@ statusConditionHooks:
 - matchers:
   - includeExtraResources: true
     resources:
-    - name: "extra-resource.apps.Deployment.default.nginx"
+    - name: "extra-resource.Deployment.apps.Deployment.default.nginx"
     conditions:
     - type: Synced
       status: "False"

--- a/fn_test.go
+++ b/fn_test.go
@@ -2848,7 +2848,7 @@ func TestRunFunction(t *testing.T) {
 					Context: resource.MustStructJSON(`
 {
   "apiextensions.crossplane.io/extra-resources": {
-    "Deployment": [
+    "IntoKey": [
       {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -2882,7 +2882,7 @@ func TestRunFunction(t *testing.T) {
           "includeExtraResources": true,
           "resources": [
             {
-              "name": "extra-resource.apps.Deployment.default.example"
+              "name": "extra-resource.IntoKey.apps.Deployment.default.example"
             }
           ],
           "conditions": [
@@ -2930,7 +2930,7 @@ func TestRunFunction(t *testing.T) {
 					Context: resource.MustStructJSON(`
 {
   "apiextensions.crossplane.io/extra-resources": {
-    "Deployment": [
+    "IntoKey": [
       {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -2969,7 +2969,7 @@ func TestRunFunction(t *testing.T) {
 					Context: resource.MustStructJSON(`
 {
   "apiextensions.crossplane.io/extra-resources": {
-    "Deployment": [
+    "IntoKey": [
       {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -3003,7 +3003,7 @@ func TestRunFunction(t *testing.T) {
           "includeExtraResources": true,
           "resources": [
             {
-              "name": "extra-resource.apps.Deployment.default.example"
+              "name": "extra-resource.IntoKey.apps.Deployment.default.example"
             }
           ],
           "conditions": [
@@ -3016,7 +3016,7 @@ func TestRunFunction(t *testing.T) {
         {
           "resources": [
             {
-              "name": "extra-resource.apps.Deployment.default.example"
+              "name": "extra-resource.IntoKey.apps.Deployment.default.example"
             }
           ],
           "conditions": [
@@ -3059,7 +3059,7 @@ func TestRunFunction(t *testing.T) {
 					Context: resource.MustStructJSON(`
 {
   "apiextensions.crossplane.io/extra-resources": {
-    "Deployment": [
+    "IntoKey": [
       {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -3094,7 +3094,7 @@ func TestRunFunction(t *testing.T) {
 					Context: resource.MustStructJSON(`
 {
   "apiextensions.crossplane.io/extra-resources": {
-    "Deployment": [
+    "IntoKey": [
       {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -3127,7 +3127,7 @@ func TestRunFunction(t *testing.T) {
           "includeExtraResources": true,
           "resources": [
             {
-              "name": "extra-resource.apps.Deployment..example"
+              "name": "extra-resource.IntoKey.apps.Deployment..example"
             }
           ],
           "conditions": [
@@ -3175,7 +3175,7 @@ func TestRunFunction(t *testing.T) {
 					Context: resource.MustStructJSON(`
 {
   "apiextensions.crossplane.io/extra-resources": {
-    "Deployment": [
+    "IntoKey": [
       {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -3209,7 +3209,7 @@ func TestRunFunction(t *testing.T) {
 					Context: resource.MustStructJSON(`
 {
   "apiextensions.crossplane.io/extra-resources": {
-    "Deployment": [
+    "IntoKey": [
       {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -3240,7 +3240,7 @@ func TestRunFunction(t *testing.T) {
           "includeExtraResources": true,
           "resources": [
             {
-              "name": "extra-resource.apps.Deployment..example"
+              "name": "extra-resource.IntoKey.apps.Deployment..example"
             }
           ],
           "conditions": [
@@ -3282,7 +3282,7 @@ func TestRunFunction(t *testing.T) {
 					Context: resource.MustStructJSON(`
 {
   "apiextensions.crossplane.io/extra-resources": {
-    "Deployment": [
+    "IntoKey": [
       {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -3327,7 +3327,7 @@ func TestRunFunction(t *testing.T) {
           "includeExtraResources": true,
           "resources": [
             {
-              "name": "extra-resource.apps.Deployment..example"
+              "name": "extra-resource.IntoKey.apps.Deployment..example"
             }
           ],
           "conditions": [
@@ -3392,7 +3392,7 @@ func TestRunFunction(t *testing.T) {
           "includeExtraResources": true,
           "resources": [
             {
-              "name": "extra-resource.apps.Deployment..example"
+              "name": "extra-resource.IntoKey.apps.Deployment..example"
             }
           ],
           "conditions": [
@@ -3457,7 +3457,7 @@ func TestRunFunction(t *testing.T) {
           "includeExtraResources": true,
           "resources": [
             {
-              "name": "extra-resource.apps.Deployment..example"
+              "name": "extra-resource.IntoKey.apps.Deployment..example"
             }
           ],
           "conditions": [
@@ -3514,7 +3514,7 @@ func TestRunFunction(t *testing.T) {
 					Context: resource.MustStructJSON(`
 {
   "apiextensions.crossplane.io/extra-resources": {
-    "Deployment": 1
+    "IntoKey": 1
   }
 }
 `),
@@ -3529,7 +3529,7 @@ func TestRunFunction(t *testing.T) {
           "includeExtraResources": true,
           "resources": [
             {
-              "name": "extra-resource.apps.Deployment..example"
+              "name": "extra-resource.IntoKey.apps.Deployment..example"
             }
           ],
           "conditions": [
@@ -3565,14 +3565,14 @@ func TestRunFunction(t *testing.T) {
 							Type:    "StatusTransformationSuccess",
 							Status:  fnv1.Status_STATUS_CONDITION_FALSE,
 							Reason:  "InputFailure",
-							Message: ptr.To("cannot load extra-resources: unexpected extra-resources value type for Deployment: float64"),
+							Message: ptr.To("cannot load extra-resources: unexpected extra-resources value type for IntoKey: float64"),
 							Target:  fnv1.Target_TARGET_COMPOSITE.Enum(),
 						},
 					},
 					Context: resource.MustStructJSON(`
 {
   "apiextensions.crossplane.io/extra-resources": {
-    "Deployment": 1
+    "IntoKey": 1
   }
 }
 `),
@@ -3588,7 +3588,7 @@ func TestRunFunction(t *testing.T) {
 					Context: resource.MustStructJSON(`
 {
   "apiextensions.crossplane.io/extra-resources": {
-    "Deployment": [
+    "IntoKey": [
       1
     ]
   }
@@ -3605,7 +3605,7 @@ func TestRunFunction(t *testing.T) {
           "includeExtraResources": true,
           "resources": [
             {
-              "name": "extra-resource.apps.Deployment..example"
+              "name": "extra-resource.IntoKey.apps.Deployment..example"
             }
           ],
           "conditions": [
@@ -3641,14 +3641,14 @@ func TestRunFunction(t *testing.T) {
 							Type:    "StatusTransformationSuccess",
 							Status:  fnv1.Status_STATUS_CONDITION_FALSE,
 							Reason:  "InputFailure",
-							Message: ptr.To("cannot load extra-resources: unexpected extra-resources value type for Deployment [0]: float64"),
+							Message: ptr.To("cannot load extra-resources: unexpected extra-resources value type for IntoKey [0]: float64"),
 							Target:  fnv1.Target_TARGET_COMPOSITE.Enum(),
 						},
 					},
 					Context: resource.MustStructJSON(`
 {
   "apiextensions.crossplane.io/extra-resources": {
-    "Deployment": [
+    "IntoKey": [
       1
     ]
   }

--- a/input/v1beta1/input.go
+++ b/input/v1beta1/input.go
@@ -98,11 +98,12 @@ type Matcher struct {
 	// list of matched resources.
 	IncludeCompositeAsResource *bool `json:"includeCompositeAsResource"`
 
-	// IncludeExtraResources will check for resources from the extra-resources
-	// function and include them to be matched against. These resources will have
-	// names that follow the pattern
-	// "extra-resource.<group>.<kind>.<namespace>.name"
-	// (e.g., extra-resource.apps.Deployment.default.nginx)
+	// IncludeExtraResources will include resources from the extra-resources
+	// function to be matched against. These resources will have names that follow
+	// the pattern "extra-resource.<into>.<group>.<kind>.<namespace>.<name>".
+	// 'into' refers to the extra-resource function's Input field at
+	// <Input>.spec.extraResources[*].into. An example name:
+	// "extra-resource.Deployment.apps.Deployment.default.nginx".
 	IncludeExtraResources *bool `json:"includeExtraResources"`
 }
 


### PR DESCRIPTION
### Description of your changes

Adds the `<Input>.spec.extraResources[*].into` field to the name paths for extra resource names.

The name nows follows the pattern `extra-resource.<into>.<group>.<kind>.<namespace>.<name>` (e.g., extra-resource.Deployment.apps.Deployment.default.nginx).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
